### PR TITLE
Updating command to create documentation

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -19,7 +19,7 @@ jobs:
         - |
           cd compliance-repository
           compliance-masonry-go --verbose get
-          compliance-masonry-go --verbose docs gitbook -e ../masonry-exports FedRAMP-med
+          compliance-masonry-go --verbose docs gitbook -e ../masonry-exports FedRAMP-moderate
   - task: create-gitbook
     config:
       platform: linux


### PR DESCRIPTION
I changed the name of FedRAMP-med to FedRAMP-moderate in the CM certifications, which broke the pipeline. This commit fixes it. 
