### PR TITLE
add link checking

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -34,11 +34,38 @@ jobs:
         args:
         - -exc
         - |
-          mv compliance-repository/book.json prepared-gitbook/book.json 
+          mv compliance-repository/book.json prepared-gitbook/book.json
           mv compliance-repository/Staticfile prepared-gitbook/Staticfile
           mv masonry-exports/* prepared-gitbook/
           cd prepared-gitbook
           gitbook build
+  - task: check-links
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: ruby
+          tag: '2.3-alpine'
+      inputs:
+      - name: prepared-gitbook
+      run:
+        path: sh
+        args:
+        - -exc
+        - |
+          # install system libraries for FFI and Nokogiri
+          # https://github.com/ffi/ffi/issues/485#issuecomment-209778567
+          # https://github.com/gliderlabs/docker-alpine/issues/53#issuecomment-179486583
+          apk add --update \
+            build-base \
+            libffi-dev \
+            libxml2-dev \
+            libxslt-dev
+          gem install nokogiri -- --use-system-libraries
+          gem install html-proofer
+          cd prepared-gitbook/_book
+          htmlproofer --disable-external .
   - put: deploy-documentation
     params:
       manifest: compliance-repository/manifest.yaml


### PR DESCRIPTION
https://trello.com/c/BPLKQCPk/137-set-up-link-verification

This pull request adds (internal) link verification to the built gitbook site using [HTML Proofer](https://github.com/gjtorikian/html-proofer).

![screen shot 2016-04-14 at 2 45 03 am](https://cloud.githubusercontent.com/assets/86842/14519138/eaea1230-01ea-11e6-911d-3784538ce7e5.png)

Now that I've gone through the (surprising) trouble of getting this working, though, I'm wondering if we should be catching these issues in [cg-compliance](https://github.com/18F/cg-compliance) via Travis. That way, the links don't get broken before they are merged. Hmmmm...

/cc @ctro @davidebest @geramirez @LinuxBozo (FYI you don't seem to be watching this repository)
