### PR TITLE
Adding a note that this should not be deployed with a user CF account.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ This repo also contains the Dockerfile for creating the images used in the pipel
 1. Go to [the pipeline page](http://192.168.100.4:8080/pipelines/compliance-documentation)
 
 Note this won't actually complete the deployment to compliance.cloud.gov...you will need to modify `credentials.yml` and run `set-pipeline` again for that to work.
+
+## Production Notes
+
+1. In production, this should not run under an individual's cloud.gov account. It is currently deployed using the `cloudgov-deployer` limited deployment user. Ask in #cloud-gov-support if you wish to deploy this pipeline and do not know how to get those credentials.

--- a/credentials.yml.example
+++ b/credentials.yml.example
@@ -1,5 +1,5 @@
 API: https://api.cloud.gov
-USERNAME: cloudgov-deployer 
+USERNAME: cloudgov-deployer
 ORG: TARGET_ORG
 SPACE: TARGET_SPACE
 PASSWORD: PASSWORD

--- a/credentials.yml.example
+++ b/credentials.yml.example
@@ -1,5 +1,5 @@
 API: https://api.cloud.gov
-USERNAME: FIRSTNAME.LASTNAME@gsa.gov
+USERNAME: cloudgov-deployer 
 ORG: TARGET_ORG
 SPACE: TARGET_SPACE
 PASSWORD: PASSWORD


### PR DESCRIPTION
Production pipelines shouldn't be deployed using an individual's CF account, but rather a single-purpose 'deployer user'. This adds a note to the readme to that effect, and changes the example credentials file to use it.
