### PR TITLE
Added param for manifest to allow for env-specific manifests

### DIFF
--- a/credentials.yml.example
+++ b/credentials.yml.example
@@ -3,3 +3,4 @@ USERNAME: cloudgov-deployer
 ORG: TARGET_ORG
 SPACE: TARGET_SPACE
 PASSWORD: PASSWORD
+MANIFEST: compliance-repository/manifest-govcloud.yml

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1,5 +1,5 @@
 jobs:
-- name: Deploy compliance.cloud.gov
+- name: Deploy compliance documentation
   public: true
   plan:
   - get: compliance-repository
@@ -41,7 +41,7 @@ jobs:
           gitbook build
   - put: deploy-documentation
     params:
-      manifest: compliance-repository/manifest.yaml
+      manifest: {{MANIFEST}}
       path: prepared-gitbook
 
 resources:


### PR DESCRIPTION
This patch adds a param for manifest. This allows for us to use
environment specific manifests which allows us to specify specific
routes/domains for each environment. This is necessary for migrating to
GovCloud

Depends on https://github.com/18F/cg-compliance/pull/187