### PR TITLE
Install gitbook plugins at runtime

### DIFF
--- a/gitbook-docker/Dockerfile
+++ b/gitbook-docker/Dockerfile
@@ -1,3 +1,2 @@
 FROM node:5.5.0-slim
 RUN npm install -g gitbook-cli && gitbook install latest
-RUN npm install gitbook-plugin-ga

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -38,6 +38,7 @@ jobs:
           mv compliance-repository/Staticfile prepared-gitbook/Staticfile
           mv masonry-exports/* prepared-gitbook/
           cd prepared-gitbook
+          gitbook install
           gitbook build
   - put: deploy-documentation
     params:


### PR DESCRIPTION
Prior to this patch, there was an update to gitbook and where it
looks for plugins. Since the Google Analytics plugin was not installed
in the local "node_modules" folder or the global node_modules folder,
it failed to find the plugin.
It can be icky to keep trying to pre-emptively installing plugins,
instead let gitbook handle installation of plugins via it's `gitbook
install` command at runtime instead of the npm install command at image
build